### PR TITLE
Add non-A10 processor buttonhelper support and several devices suppport 

### DIFF
--- a/button_helper.c
+++ b/button_helper.c
@@ -13,7 +13,7 @@
 #define TOO_MANY_MATCHES (uint32_t *)0x1
 #define SKIPPED (uint32_t *)0x2
 
-const volatile uint32_t * const gpio_base = 0x20f100000;
+volatile uint32_t *gpio_base;
 
 // fflush(stdout) wasn't working so this function forces a flush
 void flush_spin(uint32_t usec) {
@@ -48,6 +48,10 @@ void find_buttons() {
 		device_model = "(unknown)";
 	}
 	printf("\nDevice: %s\n\n", device_model);
+
+	// https://github.com/checkra1n/pongoOS/blob/09d82c8efcc28fc09e3391f48f41cb7b79a00808/src/drivers/gpio/gpio.c#L38
+	gpio_base = dt_get_u32_prop("gpio", "reg") + gIOBase;
+	printf("gpio_base: 0x%llx\n\n", gpio_base);
 
 	static uint8_t possible_addresses[0x400];
 

--- a/main.c
+++ b/main.c
@@ -17,6 +17,42 @@ struct device_model {
 
 const struct device_model devices[] = {
 	{
+		.name = "iPhone6,2",
+		.volume_up = 0x20e300010,
+		.volume_down = 0x20e300014,
+		.mute_switch = 0x20e300040,
+		.power_button = 0x20e30000c,
+		.home_button = 0x20e300008,
+		.home_button_at_right = 1
+	},
+	{
+		.name = "iPhone7,2",
+		.volume_up = 0x20e3000b4,
+		.volume_down = 0x20e3000b8,
+		.mute_switch = 0x20e30020c,
+		.power_button = 0x20e300084,
+		.home_button = 0x20e300080,
+		.home_button_at_right = 1
+	},
+	{
+		.name = "iPhone8,1",
+		.volume_up = 0x20f100108,
+		.volume_down = 0x20f10010c,
+		.mute_switch = 0x20f100254,
+		.power_button = 0x20f100184,
+		.home_button = 0x20f100180,
+		.home_button_at_right = 1
+	},
+	{
+		.name = "iPhone9,1",
+		.volume_up = 0x20f10005c,
+		.volume_down = 0x20f1002d0,
+		.mute_switch = 0x20f100158,
+		.power_button = 0x20f1002cc,
+		.home_button = NULL,
+		.home_button_at_right = 0
+	},
+	{
 		.name = "iPhone9,3",
 		.volume_up = 0x20f10005c,
 		.volume_down = 0x20f1002d0,
@@ -41,6 +77,15 @@ const struct device_model devices[] = {
 		.mute_switch = NULL,
 		.power_button = 0x20f1002cc,
 		.home_button = 0x20f1002d0,
+		.home_button_at_right = 1
+	},
+	{
+		.name = "iPod9,1",
+		.volume_up = 0x20f10005c,
+		.volume_down = 0x20f1002d0,
+		.mute_switch = NULL,
+		.power_button = 0x20f1002cc,
+		.home_button = 0x20f100158,
 		.home_button_at_right = 1
 	},
 	{ .name = NULL }


### PR DESCRIPTION
* Add buttonhelper support for non-A10 processor (May close #12)
  * I just copied some codes from pongoOS and found it works.
* Add several devices suppport 
  *  However, only A10 (iPhone9,1 and iPod9,1) is playable. Other devices can't output correct graphics.