### PR TITLE
Add iPod touch (6th generation) support

### DIFF
--- a/README.md
+++ b/README.md
@@ -22,6 +22,7 @@ Currently supported devices:
 - iPhone 7 GSM (iPhone9,3)
 - iPad Pro 10.5-inch WiFi/Cellular (iPad7,4)
 - iPad 10.2-inch 7th Gen WiFi/Cellular (iPad7,12)
+- iPod Touch 6th Gen (iPod7,1)
 
 If your device is already supported, great! You won't have to modify the code. You can skip to [running BRIX](#running-brix). If your device isn't supported, adding support for your own device shouldn't be hard.
 

--- a/main.c
+++ b/main.c
@@ -80,13 +80,13 @@ const struct device_model devices[] = {
 		.home_button_at_right = 1
 	},
 	{
-	    .name = "iPod7,1",
-	    .volume_up = 0x20e3000b4,
-	    .volume_down = 0x20e3000b8,
-	    .mute_switch = NULL,
-	    .power_button = 0x20e300084,
-	    .home_button = 0x20e300080,
-	    .home_button_at_right = 1
+		.name = "iPod7,1",
+		.volume_up = 0x20e3000b4,
+		.volume_down = 0x20e3000b8,
+		.mute_switch = NULL,
+		.power_button = 0x20e300084,
+		.home_button = 0x20e300080,
+		.home_button_at_right = 1
 	},
 	{
 		.name = "iPod9,1",
@@ -156,7 +156,7 @@ void redraw_screen(chip8_t *self, chip8_event_t event) {
 
 void play_brix() {
 	srand((unsigned int)get_ticks());
-	
+
 	// find the device details
 	uint32_t len;
 	const char *device_model = (char *)dt_prop(gDeviceTree, "model", &len);
@@ -206,7 +206,7 @@ void play_brix() {
 
 			int64_t cycle_usec = ((int64_t)get_ticks() - cycle_start) / 24;
 			int64_t spin_duration = (int64_t)usec_per_instruction - cycle_usec;
-			
+
 			if (spin_duration > 0) {
 				spin((uint32_t)spin_duration);
 			}

--- a/main.c
+++ b/main.c
@@ -80,6 +80,15 @@ const struct device_model devices[] = {
 		.home_button_at_right = 1
 	},
 	{
+	    .name = "iPod7,1",
+	    .volume_up = 0x20e3000b4,
+	    .volume_down = 0x20e3000b8,
+	    .mute_switch = NULL,
+	    .power_button = 0x20e300084,
+	    .home_button = 0x20e300080,
+	    .home_button_at_right = 1
+	},
+	{
 		.name = "iPod9,1",
 		.volume_up = 0x20f10005c,
 		.volume_down = 0x20f1002d0,


### PR DESCRIPTION
This change introduces support for `iPod7,1` devices, or 6th gen iPod touch devices. 