### PR TITLE
Add patch to fix rendering on 4.8 inch devices

### DIFF
--- a/README.md
+++ b/README.md
@@ -19,10 +19,11 @@ A pongoOS module for running the BRIX game, featuring rendering code I wrote at 
 ## Compatibility
 
 Currently supported devices:
+
 - iPhone 7 GSM (iPhone9,3)
 - iPad Pro 10.5-inch WiFi/Cellular (iPad7,4)
 - iPad 10.2-inch 7th Gen WiFi/Cellular (iPad7,12)
-- iPod Touch 6th Gen (iPod7,1)
+- iPod Touch 6th Gen (iPod7,1) ([requires extra patching](#48-inch-devices))
 
 If your device is already supported, great! You won't have to modify the code. You can skip to [running BRIX](#running-brix). If your device isn't supported, adding support for your own device shouldn't be hard.
 
@@ -57,6 +58,14 @@ Address: 0x20f1000a0
 
 1. Run `make load_brix`. This will compile the module and load it in pongoOS.
 2. Run `brix` in the pongoOS shell. Your device should now be running BRIX.
+
+### 4.8-inch devices
+
+For devices with a 4.8-inch screen, a different method for rendering is required. Before building `brix`, make sure to apply the patch in `fix-rendering.patch`.
+
+```
+$ git apply -v fix-rendering.patch
+```
 
 ## Controls
 

--- a/fix-rendering.patch
+++ b/fix-rendering.patch
@@ -1,0 +1,33 @@
+Fix rendering for the following devices:
+
+* iPod Touch (all models)
+* iPhone 5s (all models)
+* Any supported device with a 4.8 inch screen
+
+=================================================
+diff -urN a/main.c b/main.c
+--- a/main.c	2023-06-02 02:06:31.000000000 +0200
++++ b/main.c	2023-06-02 00:49:29.000000000 +0200
+@@ -137,17 +137,17 @@
+ void redraw_screen(chip8_t *self, chip8_event_t event) {
+ 	const uint32_t scale = game_scale;
+ 	const uint8_t flip = device->home_button_at_right;
+-	const uint32_t yOffset = (gHeight - (CHIP8_SCREEN_WIDTH * scale)) / 2;
+-	const uint32_t xOffset = (gWidth - (CHIP8_SCREEN_HEIGHT * scale)) / 2;
+-	for (uint32_t y=event.redraw_event.y; y<event.redraw_event.y + event.redraw_event.height; y++) {
+-		for (uint32_t x=event.redraw_event.x; x<event.redraw_event.x + event.redraw_event.width; x++) {
++	const uint32_t y_offset = (gHeight - (CHIP8_SCREEN_WIDTH * scale)) / 2;
++	const uint32_t x_offset = (gWidth - (CHIP8_SCREEN_HEIGHT * scale)) / 2;
++	for (uint32_t y = 0; y < CHIP8_SCREEN_HEIGHT; y++) {
++		for (uint32_t x = 0; x < CHIP8_SCREEN_WIDTH; x++) {
+ 			uint32_t rx = x % CHIP8_SCREEN_WIDTH;
+ 			uint32_t ry = y % CHIP8_SCREEN_HEIGHT;
+ 			uint32_t tx = (flip ? rx : (CHIP8_SCREEN_WIDTH - rx - 1));
+ 			uint32_t ty = (flip ? (CHIP8_SCREEN_HEIGHT - ry - 1) : ry);
+ 			for (uint32_t sx = ty * scale; sx < (ty + 1) * scale; sx++) {
+ 				for (uint32_t sy = tx * scale; sy < (tx + 1) * scale; sy++) {
+-					gFramebuffer[gRowPixels * (sy + yOffset) + (sx + xOffset)] = self->framebuffer[rx][ry] ? 0xFFFFFFFF : 0x0;
++					gFramebuffer[gRowPixels * (sy + y_offset) + (sx + x_offset)] = self->framebuffer[rx][ry] ? 0xFFFFFFFF : 0x0;
+ 				}
+ 			}
+ 		}

--- a/fix-rendering.patch
+++ b/fix-rendering.patch
@@ -1,7 +1,7 @@
 Fix rendering for the following devices:
 
-* iPod Touch (all models)
-* iPhone 5s (all models)
+* iPod Touch (all supported models)
+* iPhone 5s (iPhone6,2)
 * Any supported device with a 4.8 inch screen
 
 =================================================


### PR DESCRIPTION
While adding support for `iPod7,1`, I ran across a patch made by Mineek that resolved the rendering issue I had. With Mineek's permission, I've decided to add this in case anyone runs into rendering issues on devices with a 4.8-inch screen.